### PR TITLE
Update mechanical duck's launch time in the wiki

### DIFF
--- a/players-guide/store-items.md
+++ b/players-guide/store-items.md
@@ -23,5 +23,5 @@ How to use the shop command.
 | 17 | Sabotage | 14 | Sabotage the weapon of another player. Their gun will jam and explode in their face the next time they press the trigger. |
 | 20 | Decoy | 8 | Attracts a duck in the next 10 minutes after purchase. |
 | 21 | Bread | 2 | Throw pieces of bread to improve the probability of seeing ducks for 1h. Bread also makes ducks stay 20 seconds longer. Multiple pieces of bread can be bought for a cumulative effect. |
-| 23 | Mechanical duck | 40 | Play a prank on other hunters by launching a fake duck. They will not gain any exp from it and will lose their ammo. The duck will be automatically launched 10 minutes after purchase. |
+| 23 | Mechanical duck | 40 | Play a prank on other hunters by launching a fake duck. They will not gain any exp from it and will lose their ammo. The duck will be automatically launched 90 seconds after purchase. |
 


### PR DESCRIPTION
I noticed that the mechanical duck's time in the wiki doesn't match with the real time.